### PR TITLE
Add 'arduino' (portduino) as an optional build target

### DIFF
--- a/boards/cross_platform.json
+++ b/boards/cross_platform.json
@@ -1,0 +1,15 @@
+{
+  "build": {
+    "core": "FIXMECORE",
+    "extra_flags": "-DPORTDUINO_CROSSPLATFORM",
+    "variant": "native"
+  },
+  "upload": {
+    "maximum_ram_size": 99999999,
+    "maximum_size": 99999999
+  },
+  "frameworks": ["arduino"],
+  "name": "Portduino",
+  "url": "https://github.com/geeksville/framework-portduino",
+  "vendor": "Geeksville Industries, LLC"
+}

--- a/boards/linux_hardware.json
+++ b/boards/linux_hardware.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "FIXMECORE",
-    "extra_flags": "-DFIXMEFLAG",
+    "extra_flags": "-DPORTDUINO_LINUX_HARDWARE",
     "variant": "native"
   },
   "upload": {

--- a/boards/native.json
+++ b/boards/native.json
@@ -1,0 +1,15 @@
+{
+  "build": {
+    "core": "FIXMECORE",
+    "extra_flags": "-DFIXMEFLAG",
+    "variant": "native"
+  },
+  "upload": {
+    "maximum_ram_size": 99999999,
+    "maximum_size": 99999999
+  },
+  "frameworks": ["arduino"],
+  "name": "Portduino",
+  "url": "https://github.com/geeksville/framework-portduino",
+  "vendor": "Geeksville Industries, LLC"
+}

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -70,8 +70,7 @@ env.Append(
 
     LIBS=[
         "stdc++",
-        "m",
-        "psocksxx"
+        "m"
     ],
 
     LIBSOURCE_DIRS=[

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -1,0 +1,112 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Arduino
+
+Arduino Wiring-based Framework allows writing cross-platform software to
+control devices attached to a wide range of Arduino boards to create all
+kinds of creative coding, interactive objects, spaces or physical experiences.
+
+http://arduino.cc/en/Reference/HomePage
+"""
+
+import os
+
+from SCons.Script import DefaultEnvironment
+
+env = DefaultEnvironment()
+platform = env.PioPlatform()
+board = env.BoardConfig()
+core = board.get("build.core")
+
+FRAMEWORK_DIR = platform.get_package_dir("framework-portduino")
+assert os.path.isdir(FRAMEWORK_DIR)
+
+env.Append(
+    CPPDEFINES=[
+        ("ARDUINO", 4403), # FIXME, find how these numbers are assigned!
+        "PORTDUINO" # FIXME, should we use some different convention?
+        # ("CONFIG_MANUFACTURER", '\\"ASR\\"'),
+        # ("CONFIG_DEVICE_MODEL", '\\"6501\\"'),
+        # ("CONFIG_VERSION", '\\"v4.0\\"'),
+    ],
+
+    CCFLAGS=[
+        "-w",
+        "-Wall",
+        "-ggdb"
+    ],
+
+    CXXFLAGS=[
+        # "-fno-exceptions",
+    ],
+
+    LINKFLAGS=[
+        "-ggdb"
+    ],
+
+    CPPPATH=[
+        os.path.join(FRAMEWORK_DIR, "cores", "portduino"),
+        os.path.join(FRAMEWORK_DIR, "cores", "portduino", "FS"),
+        os.path.join(FRAMEWORK_DIR, "cores", "arduino", "api")
+        # os.path.join(FRAMEWORK_DIR, "cores", core),
+        # os.path.join(FRAMEWORK_DIR, "cores", core, "cores"),
+        # os.path.join(FRAMEWORK_DIR, "cores", core, "Serial"),
+        # os.path.join(FRAMEWORK_DIR, "cores", core, "Wire"),
+        # os.path.join(FRAMEWORK_DIR, "cores", core, "SPI"),
+    ],
+
+    LIBS=[
+        "stdc++",
+        "m",
+        "psocksxx"
+    ],
+
+    LIBSOURCE_DIRS=[
+        os.path.join(FRAMEWORK_DIR, "libraries")
+    ]
+)
+
+#
+# Target: Build Core Library
+#
+
+libs = []
+
+if "build.variant" in env.BoardConfig():
+    variants_dir = os.path.join(
+        "$PROJECT_DIR", board.get("build.variants_dir")) if board.get(
+            "build.variants_dir", "") else os.path.join(FRAMEWORK_DIR, "variants")
+    env.Append(
+        CPPPATH=[
+            os.path.join(variants_dir, board.get("build.variant"))
+        ]
+    )
+    libs.append(env.BuildLibrary(
+        os.path.join("$BUILD_DIR", "FrameworkArduinoVariant"),
+        os.path.join(variants_dir, board.get("build.variant"))
+    ))
+
+libs.append(env.BuildLibrary(
+    os.path.join("$BUILD_DIR", "FrameworkArduino"),
+    os.path.join(FRAMEWORK_DIR, "cores"),
+    src_filter=[
+        "+<*>",
+        "-<%s/projects/PSoC4/CyBootAsmIar.s>" % core,
+        "-<%s/projects/PSoC4/CyBootAsmRv.s>" % core
+    ]
+))
+
+env.Prepend(LIBS=libs)

--- a/platform.json
+++ b/platform.json
@@ -12,6 +12,19 @@
   "engines": {
     "platformio": "^5"
   },
+  "packages": {
+    "framework-portduino": {
+      "type": "framework",
+      "version": "https://github.com/geeksville/framework-portduino.git",
+      "optional": true
+    }
+  },
+  "frameworks": {
+    "arduino": {
+      "package": "framework-portduino",
+      "script": "builder/frameworks/arduino.py"
+    }
+  },  
   "repository": {
     "type": "git",
     "url": "https://github.com/platformio/platform-native.git"


### PR DESCRIPTION
This PR is just a draft for now, once portduino gets a bit more mature I can send it in if you want it.

Mostly adding this draft so that interested parties can discuss the idea here: https://community.platformio.org/t/portduino-a-new-platform-framework-to-allow-running-arduino-code-on-linux-feedback-requested/22968
