### PR TITLE
Allow set compiler env variables

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -20,11 +20,6 @@ from SCons.Script import COMMAND_LINE_TARGETS, AlwaysBuild, Default, DefaultEnvi
 
 env = DefaultEnvironment()
 
-# Remove generic C/C++ tools
-for k in ("CC", "CXX"):
-    if k in env:
-        del env[k]
-
 # Preserve C and C++ build flags
 backup_cflags = env.get("CFLAGS", [])
 backup_cxxflags = env.get("CXXFLAGS", [])


### PR DESCRIPTION
When we have multiples compilers, we need a way to set it using env vars and pio should respect it.

I can’t see any drawback, as users just have these env var set when they explicit want to use an specific compiler.

I usually set these env var in a pre script too.